### PR TITLE
bug fix:

### DIFF
--- a/app/src/main/java/org/appspot/apprtc/RoomParametersFetcher.java
+++ b/app/src/main/java/org/appspot/apprtc/RoomParametersFetcher.java
@@ -208,8 +208,10 @@ public class RoomParametersFetcher {
       JSONObject server = servers.getJSONObject(i);
       String url = server.getString("urls");
       String credential = server.has("credential") ? server.getString("credential") : "";
-        PeerConnection.IceServer turnServer =
-            PeerConnection.IceServer.builder(url)
+      String username = server.has("username") ? server.getString("username") : "";
+      PeerConnection.IceServer turnServer =
+          PeerConnection.IceServer.builder(url)
+              .setUsername(username)
               .setPassword(credential)
               .createIceServer();
       ret.add(turnServer);


### PR DESCRIPTION
[my work]
added username field parsing from pc config.

[resolved issue]
original source code doesn't work with this pc config:
ICE_SERVER_OVERRIDE  = [
   {
     "urls": "turn:webrtc-server.com:3478?transport=udp",
     "username": "abc",
     "credential": "def"
   },
]